### PR TITLE
Refactor parameters, named queries, exceptions and more

### DIFF
--- a/examples/arguments.py
+++ b/examples/arguments.py
@@ -26,7 +26,7 @@ class Query(GQLQuery):
 
 
 # Generate the GraphQL query string and instantiate variables
-query_str = Query.get_query_string(named=False)
+query_str = Query.get_query_string(include_name=False)
 print(query_str)
 
 

--- a/examples/variables.py
+++ b/examples/variables.py
@@ -3,11 +3,11 @@ import os
 import requests
 from pydantic import Field
 
-from pygraphic import GQLParameters, GQLQuery, GQLType
+from pygraphic import GQLQuery, GQLType, GQLVariables
 
 
 # Define the query variables
-class Variables(GQLParameters):
+class Variables(GQLVariables):
     repo_owner: str
     repo_name: str
     pull_requests_count: int
@@ -28,7 +28,7 @@ class Repository(GQLType):
 
 
 # Define query model and attach variables to it
-class PygraphicPullRequests(GQLQuery, parameters=Variables):
+class PygraphicPullRequests(GQLQuery, variables=Variables):
     repository: Repository = Field(owner=Variables.repo_owner, name=Variables.repo_name)
 
 

--- a/pygraphic/__init__.py
+++ b/pygraphic/__init__.py
@@ -1,7 +1,7 @@
-from . import defaults, types
-from ._gql_variables import GQLVariables
+from . import defaults, exceptions, types
 from ._gql_query import GQLQuery
 from ._gql_type import GQLType
+from ._gql_variables import GQLVariables
 
 
-__all__ = ["defaults", "GQLVariables", "GQLType", "GQLQuery", "types"]
+__all__ = ["defaults", "exceptions", "GQLVariables", "GQLType", "GQLQuery", "types"]

--- a/pygraphic/__init__.py
+++ b/pygraphic/__init__.py
@@ -1,7 +1,7 @@
 from . import defaults, types
-from ._gql_parameters import GQLParameters
+from ._gql_variables import GQLVariables
 from ._gql_query import GQLQuery
 from ._gql_type import GQLType
 
 
-__all__ = ["defaults", "GQLParameters", "GQLType", "GQLQuery", "types"]
+__all__ = ["defaults", "GQLVariables", "GQLType", "GQLQuery", "types"]

--- a/pygraphic/_gql_query.py
+++ b/pygraphic/_gql_query.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Optional
 
 import pydantic

--- a/pygraphic/_gql_query.py
+++ b/pygraphic/_gql_query.py
@@ -11,17 +11,17 @@ from .types import class_to_graphql_type
 
 class GQLQuery(GQLType):
     @classmethod
-    def get_query_string(cls, named: bool = True) -> str:
+    def get_query_string(cls, include_name: bool = True) -> str:
         variables: Optional[
             type[GQLVariables]
         ] = cls.__config__.variables  # type: ignore
 
-        if not named and variables is not None:
+        if variables and not include_name:
             # TODO Find a better exception type
             raise Exception("Query with variables must have a name")
 
-        def _gen():
-            if named:
+        def _generate():
+            if include_name:
                 variables_str = _get_variables_string(variables)
                 yield "query " + cls.__name__ + variables_str + " {"
             else:
@@ -30,7 +30,7 @@ class GQLQuery(GQLType):
                 yield line
             yield "}"
 
-        return "\n".join(_gen())
+        return "\n".join(_generate())
 
     class Config(pydantic.BaseConfig):
         variables: Optional[type[GQLVariables]] = None

--- a/pygraphic/_gql_query.py
+++ b/pygraphic/_gql_query.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-from typing import Iterator, Optional
+from typing import Optional
 
 import pydantic
 
 from ._gql_type import GQLType
 from ._gql_variables import GQLVariables
-from ._utils import first_only
 from .types import class_to_graphql_type
 
 
@@ -23,7 +22,7 @@ class GQLQuery(GQLType):
 
         def _gen():
             if named:
-                variables_str = "".join(_gen_variables_string(variables))
+                variables_str = _get_variables_string(variables)
                 yield "query " + cls.__name__ + variables_str + " {"
             else:
                 yield "query {"
@@ -37,15 +36,14 @@ class GQLQuery(GQLType):
         variables: Optional[type[GQLVariables]] = None
 
 
-def _gen_variables_string(variables: Optional[type[GQLVariables]]) -> Iterator[str]:
+def _get_variables_string(variables: Optional[type[GQLVariables]]) -> str:
     if variables is None or not variables.__fields__:
-        return
-    yield "("
-    for field, is_first in zip(variables.__fields__.values(), first_only()):
-        if not is_first:
-            yield ", "
-        yield "$"
-        yield field.alias
-        yield ": "
-        yield class_to_graphql_type(field.type_, allow_none=field.allow_none)
-    yield ")"
+        return ""
+
+    def _generate():
+        for field in variables.__fields__.values():
+            yield "$" + field.alias + ": " + class_to_graphql_type(
+                field.type_, allow_none=field.allow_none
+            )
+
+    return "(" + ", ".join(_generate()) + ")"

--- a/pygraphic/_gql_query.py
+++ b/pygraphic/_gql_query.py
@@ -26,8 +26,8 @@ class GQLQuery(GQLType):
                 yield "query " + cls.__name__ + variables_str + " {"
             else:
                 yield "query {"
-            for line in cls.generate_query_lines(nest_level=1):
-                yield line
+            for line in cls.generate_query_lines():
+                yield "  " + line
             yield "}"
 
         return "\n".join(_generate())

--- a/pygraphic/_gql_query.py
+++ b/pygraphic/_gql_query.py
@@ -6,6 +6,7 @@ import pydantic
 
 from ._gql_type import GQLType
 from ._gql_variables import GQLVariables
+from .exceptions import QueryGenerationError
 from .types import class_to_graphql_type
 
 
@@ -17,8 +18,7 @@ class GQLQuery(GQLType):
         ] = cls.__config__.variables  # type: ignore
 
         if variables and not include_name:
-            # TODO Find a better exception type
-            raise Exception("Query with variables must have a name")
+            raise QueryGenerationError("Query with variables must include a name")
 
         def _generate():
             if include_name:

--- a/pygraphic/_gql_query.py
+++ b/pygraphic/_gql_query.py
@@ -4,8 +4,8 @@ from typing import Iterator, Optional
 
 import pydantic
 
-from ._gql_parameters import GQLParameters
 from ._gql_type import GQLType
+from ._gql_variables import GQLVariables
 from ._utils import first_only
 from .types import class_to_graphql_type
 
@@ -13,18 +13,18 @@ from .types import class_to_graphql_type
 class GQLQuery(GQLType):
     @classmethod
     def get_query_string(cls, named: bool = True) -> str:
-        parameters: Optional[
-            type[GQLParameters]
-        ] = cls.__config__.parameters  # type: ignore
+        variables: Optional[
+            type[GQLVariables]
+        ] = cls.__config__.variables  # type: ignore
 
-        if not named and parameters is not None:
+        if not named and variables is not None:
             # TODO Find a better exception type
-            raise Exception("Query with parameters must have a name")
+            raise Exception("Query with variables must have a name")
 
         def _gen():
             if named:
-                params = "".join(_gen_parameter_string(parameters))
-                yield "query " + cls.__name__ + params + " {"
+                variables_str = "".join(_gen_variables_string(variables))
+                yield "query " + cls.__name__ + variables_str + " {"
             else:
                 yield "query {"
             for line in cls.generate_query_lines(nest_level=1):
@@ -34,14 +34,14 @@ class GQLQuery(GQLType):
         return "\n".join(_gen())
 
     class Config(pydantic.BaseConfig):
-        parameters: Optional[type[GQLParameters]] = None
+        variables: Optional[type[GQLVariables]] = None
 
 
-def _gen_parameter_string(parameters: Optional[type[GQLParameters]]) -> Iterator[str]:
-    if parameters is None or not parameters.__fields__:
+def _gen_variables_string(variables: Optional[type[GQLVariables]]) -> Iterator[str]:
+    if variables is None or not variables.__fields__:
         return
     yield "("
-    for field, is_first in zip(parameters.__fields__.values(), first_only()):
+    for field, is_first in zip(variables.__fields__.values(), first_only()):
         if not is_first:
             yield ", "
         yield "$"

--- a/pygraphic/_gql_type.py
+++ b/pygraphic/_gql_type.py
@@ -18,14 +18,14 @@ class GQLType(pydantic.BaseModel):
         fields = typing.get_type_hints(cls)
         for field_name, field_type in fields.items():
             field = cls.__fields__[field_name]
-            params = "".join(_gen_parameter_string(field.field_info.extra))
+            arguments_str = "".join(_gen_arguments_string(field.field_info.extra))
             if typing.get_origin(field_type) is list:
                 args = typing.get_args(field_type)
                 assert len(args) == 1
                 field_type = args[0]
             if typing.get_origin(field_type) is UnionType:
                 sub_types = typing.get_args(field_type)
-                yield "  " * nest_level + field.alias + params + " {"
+                yield "  " * nest_level + field.alias + arguments_str + " {"
                 for sub_type in sub_types:
                     if sub_type is object:
                         continue
@@ -42,12 +42,12 @@ class GQLType(pydantic.BaseModel):
                 raise Exception(f"Type {field_type} not supported")
             if issubclass(field_type, GQLType):
                 field_type.update_forward_refs()
-                yield "  " * nest_level + field.alias + params + " {"
+                yield "  " * nest_level + field.alias + arguments_str + " {"
                 for line in field_type.generate_query_lines(nest_level=nest_level + 1):
                     yield line
                 yield "  " * nest_level + "}"
                 continue
-            yield "  " * nest_level + field.alias + params
+            yield "  " * nest_level + field.alias + arguments_str
             continue
 
     class Config:
@@ -55,11 +55,11 @@ class GQLType(pydantic.BaseModel):
         allow_population_by_field_name = True
 
 
-def _gen_parameter_string(parameters: dict[str, Any]) -> Iterator[str]:
-    if not parameters:
+def _gen_arguments_string(arguments: dict[str, Any]) -> Iterator[str]:
+    if not arguments:
         return
     yield "("
-    for (name, value), is_first in zip(parameters.items(), first_only()):
+    for (name, value), is_first in zip(arguments.items(), first_only()):
         if not is_first:
             yield ", "
         yield default_alias_generator(name)

--- a/pygraphic/_gql_type.py
+++ b/pygraphic/_gql_type.py
@@ -14,7 +14,7 @@ from .exceptions import QueryGenerationError
 
 class GQLType(pydantic.BaseModel):
     @classmethod
-    def generate_query_lines(cls, nest_level: int = 0) -> Iterator[str]:
+    def generate_query_lines(cls) -> Iterator[str]:
         fields = typing.get_type_hints(cls)
         for field_name, field_type in fields.items():
             field = cls.__fields__[field_name]
@@ -28,7 +28,7 @@ class GQLType(pydantic.BaseModel):
                 field_type = args[0]
             if typing.get_origin(field_type) is UnionType:
                 sub_types = typing.get_args(field_type)
-                yield "  " * nest_level + field.alias + arguments_str + " {"
+                yield field.alias + arguments_str + " {"
                 for sub_type in sub_types:
                     if sub_type is object:
                         continue
@@ -37,24 +37,22 @@ class GQLType(pydantic.BaseModel):
                             f"Member '{sub_type}' of a union type"
                             f"must be a subtype of '{GQLType.__name__}'"
                         )
-                    yield "  " * (nest_level + 1) + "... on " + sub_type.__name__ + " {"
-                    for line in sub_type.generate_query_lines(
-                        nest_level=nest_level + 2
-                    ):
-                        yield line
-                    yield "  " * (nest_level + 1) + "}"
-                yield "  " * nest_level + "}"
+                    yield "  " + "... on " + sub_type.__name__ + " {"
+                    for line in sub_type.generate_query_lines():
+                        yield "  " * 2 + line
+                    yield "  " + "}"
+                yield "}"
                 continue
             if not inspect.isclass(field_type):
                 raise QueryGenerationError(f"Type {field_type} is not supported")
             if issubclass(field_type, GQLType):
                 field_type.update_forward_refs()
-                yield "  " * nest_level + field.alias + arguments_str + " {"
-                for line in field_type.generate_query_lines(nest_level=nest_level + 1):
-                    yield line
-                yield "  " * nest_level + "}"
+                yield field.alias + arguments_str + " {"
+                for line in field_type.generate_query_lines():
+                    yield "  " + line
+                yield "}"
                 continue
-            yield "  " * nest_level + field.alias + arguments_str
+            yield field.alias + arguments_str
             continue
 
     class Config:

--- a/pygraphic/_gql_variables.py
+++ b/pygraphic/_gql_variables.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any
 
 import pydantic

--- a/pygraphic/_gql_variables.py
+++ b/pygraphic/_gql_variables.py
@@ -14,7 +14,7 @@ from .defaults import default_alias_generator
 class ModelMetaclass(pydantic.main.ModelMetaclass):
     def __getattr__(cls, __name: str) -> Any:
         try:
-            mcs: type[GQLParameters] = cls  # type: ignore
+            mcs: type[GQLVariables] = cls  # type: ignore
             return mcs.__fields__[__name]
         except KeyError:
             raise AttributeError(
@@ -22,7 +22,7 @@ class ModelMetaclass(pydantic.main.ModelMetaclass):
             )
 
 
-class GQLParameters(pydantic.BaseModel, metaclass=ModelMetaclass):
+class GQLVariables(pydantic.BaseModel, metaclass=ModelMetaclass):
     def json(self, **kwargs: Any) -> str:
         return super().json(by_alias=True, **kwargs)
 

--- a/pygraphic/_utils.py
+++ b/pygraphic/_utils.py
@@ -1,7 +1,0 @@
-from typing import Iterator
-
-
-def first_only() -> Iterator[bool]:
-    yield True
-    while True:
-        yield False

--- a/pygraphic/exceptions.py
+++ b/pygraphic/exceptions.py
@@ -1,0 +1,2 @@
+class QueryGenerationError(Exception):
+    pass

--- a/pygraphic/types.py
+++ b/pygraphic/types.py
@@ -18,7 +18,7 @@ def class_to_graphql_type(python_class: type, allow_none: bool) -> str:
         else:
             return type_ + "!"
     except KeyError:
-        raise KeyError(
-            f"Type '{python_class.__name__}' could not be converted to a GraphQL type."
+        raise TypeError(
+            f"Type '{python_class}' could not be converted to a GraphQL type."
             "See pygraphic.types.register_graphql_type"
         )

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -4,7 +4,7 @@ from pygraphic.types import class_to_graphql_type, register_graphql_type
 
 
 def test_class_to_typename_crashes_on_unknown_class():
-    with pytest.raises(KeyError) as e_info:
+    with pytest.raises(TypeError) as e_info:
         class_to_graphql_type(object, allow_none=True)
 
 


### PR DESCRIPTION
## Breaking changes
- `Parameters` are now correctly named `variables` and `arguments`
- Argument `named` of function `GQLQuery::get_query_string` is renamed to `include_name`
- New `QueryGenerationException`s are raised instead of `Exceptions` and `AssertError`s